### PR TITLE
Adds BootstrapValidator behavior

### DIFF
--- a/lib/behaviors/bootstrapvalidator-behavior.js
+++ b/lib/behaviors/bootstrapvalidator-behavior.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var Marionette = require('backbone.marionette'),
+  _ = require('underscore');
+
+require('bootstrapValidator');
+
+module.exports = Marionette.Behavior.extend({
+    onShow: function() {
+        _(this.options.targets).forEach(function(target) {
+            var globalOptions = this.options.options;
+
+            if(_.isString(target)) {
+                if(target === '@') {
+                    this.$el.bootstrapValidator(globalOptions);
+                } else {
+                    var selector = Marionette.normalizeUIString(target, Object.getPrototypeOf(this.view).ui);
+
+                    this.$(selector).bootstrapValidator(globalOptions);
+                }
+            } else {
+                var localOptions = target.options;
+                var options = _.extend({}, globalOptions, localOptions);
+                var selector = Marionette.normalizeUIString(target.selector, Object.getPrototypeOf(this.view).ui);
+
+                this.$(selector).bootstrapValidator(options);
+            }
+        }, this);
+    }
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
     jQueryBehavior: require('./behaviors/jquery-behavior.js'),
-    StickitBehavior: require('./behaviors/stickit-behavior.js')
+    StickitBehavior: require('./behaviors/stickit-behavior.js'),
+    bootstrapValidator: require('./behaviors/bootstrapvalidator-behavior.js')
 };


### PR DESCRIPTION
I have added [BootstrapValidator](https://github.com/nghuuphuoc/bootstrapvalidator) to the behaviors.

The [options/settings](http://bootstrapvalidator.com/settings/) can be passed into the behaviors options

``` js

  behaviors: {
    bootstrapValidator: {
      message: 'The field is not valid',
      feedbackIcons: {
        valid: 'fa fa-check',
        invalid: 'fa fa-times',
        validating: 'fa fa-refresh'
      }
    }
  }

```

The form target could be done better, do you have any suggestions/comments?

For now, it expects the target form to be declare into `this.view.ui.form`.

``` js
  ui: {
    form: 'form#myform'
  }

```

Also, I am not sure if (and how) events binding behaviors (like `success.form.bv` or `error.field.bv`) should be handle within this library or into the dev's app directly.

:v: 
