### PR TITLE
Call function when options is a function

### DIFF
--- a/lib/behaviors/bootstrapvalidator-behavior.js
+++ b/lib/behaviors/bootstrapvalidator-behavior.js
@@ -1,6 +1,6 @@
 'use strict';
 
-(function(root, factory) {
+(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         define([
             'marionette',
@@ -14,15 +14,19 @@
             require('bootstrapValidator')
         );
     }
-})(this, function(Marionette, _, BootstrapValidator) {
+})(this, function (Marionette, _, BootstrapValidator) {
 
     return Marionette.Behavior.extend({
-        onShow: function() {
-            _(this.options.targets).forEach(function(target) {
+        onShow: function () {
+            _(this.options.targets).forEach(function (target) {
                 var globalOptions = this.options.options;
 
-                if(_.isString(target)) {
-                    if(target === '@') {
+                if (_.isFunction(globalOptions)) {
+                    globalOptions = globalOptions.call(this);
+                }
+
+                if (_.isString(target)) {
+                    if (target === '@') {
                         this.$el.bootstrapValidator(globalOptions);
                     } else {
                         var selector = Marionette.normalizeUIString(target, Object.getPrototypeOf(this.view).ui);
@@ -31,6 +35,11 @@
                     }
                 } else {
                     var localOptions = target.options;
+
+                    if (_.isFunction(localOptions)) {
+                        localOptions = localOptions.call(this);
+                    }
+
                     var options = _.extend({}, globalOptions, localOptions);
                     var selector = Marionette.normalizeUIString(target.selector, Object.getPrototypeOf(this.view).ui);
 


### PR DESCRIPTION
Hello it's me again! I would have like have more flexible options call, so having `.call()` would add that said flexibility.

What do you think? :smile_cat: 

Sorry for the whitespaces diff, I ran your .jsfmtrc on my file :smile: 